### PR TITLE
Silence pytest numpy warnings with 3rd party libs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,9 +4,14 @@ norecursedirs =
     dist
     build
 addopts =
-    --strict
+    --strict-markers
     --doctest-modules
     --durations=0
+# Silence numpy builtin type alias warnigns in third party libs
+# https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
+filterwarnings = ignore:.*deprecated alias.*:DeprecationWarning:tensorboard.*tensorflow_stub*:
+                 ignore:.*deprecated alias.*:DeprecationWarning:tensorboard.*tensor_util*:
+                 ignore:.*deprecated alias.*:DeprecationWarning:pyarrow.*pandas_compat*:
 
 [coverage:report]
 exclude_lines =


### PR DESCRIPTION
This silences a few warnings output when running
pytest tests caused by use of np.int etc.
in third party libraries, which is deprecated:

https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

It will be up to the libraries in question to fix,
so not relevant for us.

I also updated the deprecated --strict pytest
option to --strict-markers