### PR TITLE
Map loaded checkpoint to specified device

### DIFF
--- a/detoxify/detoxify.py
+++ b/detoxify/detoxify.py
@@ -39,7 +39,7 @@ def load_checkpoint(model_type="original", checkpoint=None, device="cpu", huggin
         checkpoint_path = MODEL_URLS[model_type]
         loaded = torch.hub.load_state_dict_from_url(checkpoint_path, map_location=device)
     else:
-        loaded = torch.load(checkpoint)
+        loaded = torch.load(checkpoint, map_location=device)
         if "config" not in loaded or "state_dict" not in loaded:
             raise ValueError(
                 "Checkpoint needs to contain the config it was trained \


### PR DESCRIPTION
I think this is correct. It's just matching how `torch.hub.load_state_dict_from_url` is called.

If you train a model on GPU, but want to deploy it on a CPU for inference, then `torch.load` should map the model to the provided device.