### PR TITLE
fix worker numbers type

### DIFF
--- a/train.py
+++ b/train.py
@@ -164,7 +164,7 @@ def cli_main():
     parser.add_argument(
         "--num_workers",
         default=10,
-        type=str,
+        type=int,
         help="number of workers used in the data loader (default: 10)",
     )
     parser.add_argument("-e", "--n_epochs", default=100, type=int, help="if given, override the num")


### PR DESCRIPTION
num_workers that used in the torch DataLoader must be an integer value and wrongly was set string type.