### PR TITLE
Limit pytorch lightning version to prevent breaking changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pytorch-lightning > 1.5.0
+pytorch-lightning > 1.5.0, < 2.0.0
 torch >= 1.10.0
 transformers == 4.22.1
 kaggle >= 1.5.8


### PR DESCRIPTION
Pytorch lightning 2.0 has [breaking changes](https://lightning.ai/docs/pytorch/stable/upgrade/from_1_9.html) that affect the training code.

If you setup a new environment with the current requirements, you'll get this error when running pytest:
```text
FAILED tests/test_trainer.py::test_trainer - TypeError: __init__() got an unexpected keyword argument 'gpus'
```

This PR fixes that by limiting pytorch lightning's version to be below 2.0.