### PR TITLE
Allow newer torch for numpy 2.0 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 requires-python = ">=3.9,<3.12"
 dependencies = [
     "sentencepiece >= 0.1.94",
-    "torch < 2.2",
+    "torch",
     "transformers >= 3",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dev = [
     "scikit-learn >= 0.23.2",
     "tqdm",
     "pre-commit",
-    "numpy<2"
+    "numpy>=2"
 ]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
     "datasets >= 1.0.2",
     "pandas >= 1.1.2",
     "pytest",
-    "pytorch-lightning<2.0.0,>1.5.0",
+    "pytorch-lightning > 1.5.0",
     "scikit-learn >= 0.23.2",
     "tqdm",
     "pre-commit",


### PR DESCRIPTION
Remove the torch upper bound, to allow installing a version compatible with numpy 2.0