### PR TITLE
Add dev dependency for numpy<2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
     "scikit-learn >= 0.23.2",
     "tqdm",
     "pre-commit",
+    "numpy<2"
 ]
 
 [tool.black]


### PR DESCRIPTION
The pytorch lightning version we're using for training is incompatible with numpy 2. We should update the training code to work with newer lightning, but in the meantime set an upper bound for numpy in the dev deps, which will make the tests pass.