### PR TITLE
Add ModernBERT config

### DIFF
--- a/configs/Toxic_comment_classification_ModernBERT.json
+++ b/configs/Toxic_comment_classification_ModernBERT.json
@@ -1,0 +1,40 @@
+{
+    "name": "Jigsaw_ModernBERT",
+    "n_gpu": 1,
+    "batch_size": 10,
+    "accumulate_grad_batches": 3,
+    "loss": "binary_cross_entropy",
+    "arch": {
+        "type": "ModernBERT",
+        "args": {
+            "num_classes": 6,
+            "model_type": "answerdotai/ModernBERT-base",
+            "model_name": "ModernBertForSequenceClassification",
+            "tokenizer_name": "AutoTokenizer"
+        }
+    },
+    "dataset": {
+        "type": "JigsawDataOriginal",
+        "args": {
+            "train_csv_file": "jigsaw_data/jigsaw-toxic-comment-classification-challenge/train.csv",
+            "test_csv_file": "jigsaw_data/jigsaw-toxic-comment-classification-challenge/val.csv",
+            "add_test_labels": false,
+            "classes": [
+                "toxicity",
+                "severe_toxicity",
+                "obscene",
+                "threat",
+                "insult",
+                "identity_attack"
+            ]
+        }
+    },
+    "optimizer": {
+        "type": "Adam",
+        "args": {
+            "lr": 3e-5,
+            "weight_decay": 3e-6,
+            "amsgrad": true
+        }
+    }
+}


### PR DESCRIPTION
Adds a [ModernBERT](https://huggingface.co/blog/modernbert) config for the original toxic comment classification challenge, using the [ModernBERT-base](https://huggingface.co/answerdotai/ModernBERT-base) model.

ModernBERT is an architecture similar to BERT leveraging more recent techniques like RoPE for long context and flash attention for faster inference. It is also trained on a variety of mainly English sources, including scientific articles and code.

Currently requires installing transformers from git to train: https://github.com/huggingface/transformers/issues/35362#issuecomment-2557017167

```
CUDA_VISIBLE_DEVICES=1 python train.py -c configs/Toxic_comment_classification_ModernBERT.json
```