### PR TITLE
Set TOKENIZERS_PARALLELISM to false in train.py

### DIFF
--- a/train.py
+++ b/train.py
@@ -1,9 +1,12 @@
+# flake8: noqa: E402
 import argparse
 import json
 import os
 
-import pytorch_lightning as pl
+# Disable tokenizer parallelism to avoid deadlocks due to forking
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
+import pytorch_lightning as pl
 import src.data_loaders as module_data
 import torch
 from pytorch_lightning.callbacks import ModelCheckpoint


### PR DESCRIPTION
Avoids the warning about "The current process just got forked. Disabling parallelism to avoid deadlocks"

It isn't that clear why the warning happens, since we don't do tokenization in the dataloader workers.