### PR TITLE
Patch for loading config locally 

### DIFF
--- a/detoxify/detoxify.py
+++ b/detoxify/detoxify.py
@@ -18,10 +18,13 @@ def get_model_and_tokenizer(
     model_type, model_name, tokenizer_name, num_classes, state_dict, huggingface_config_path=None
 ):
     model_class = getattr(transformers, model_name)
-    config = model_class.config_class.from_pretrained(model_type, num_labels=num_classes)
+    if huggingface_config_path is not None:
+        config = model_class.config_class.from_pretrained(huggingface_config_path, num_labels=num_classes, local_files_only=True)
+    else:
+        config = model_class.config_class.from_pretrained(model_type, num_labels=num_classes)
     model = model_class.from_pretrained(
         pretrained_model_name_or_path=None,
-        config=huggingface_config_path or config,
+        config=config,
         state_dict=state_dict,
         local_files_only=huggingface_config_path is not None,
     )


### PR DESCRIPTION
### Issue:
We were facing an issue when using detoxify in China where it would try to download the config from Hugging Face (and running into timeout issues with the firewall) even when the huggingface_config_path was specified. This fix should address that.

### **Solution**
Load config locally from huggingface_config_path (local directory) if provided.